### PR TITLE
fix gray background when tooltip opened

### DIFF
--- a/src/ui/public/styles/base.less
+++ b/src/ui/public/styles/base.less
@@ -60,6 +60,7 @@ ul.navbar-inline li {
 .content {
   .real-flex-parent(@flow: row nowrap);
   width: 100%;
+  min-height: 100vh;
   height: 100%;
   overflow: hidden;
 


### PR DESCRIPTION
<img width="2045" alt="screen shot 2018-03-13 at 8 24 02 am" src="https://user-images.githubusercontent.com/373691/37347645-ebe06882-2697-11e8-9836-035a9985994c.png">
