### PR TITLE
Refactor mapCapabilities into two functions

### DIFF
--- a/src/core_plugins/kibana/public/management/sections/indices/index.js
+++ b/src/core_plugins/kibana/public/management/sections/indices/index.js
@@ -129,7 +129,7 @@ uiModules.get('apps/management')
             }
             return 0;
           });
-          console.log('hellooooooo');
+
           updateIndexPatternList($scope, indexPatternCreationOptions, $scope.defaultIndex, $scope.indexPatternList);
         };
 

--- a/x-pack/plugins/rollup/server/routes/api/index_patterns.js
+++ b/x-pack/plugins/rollup/server/routes/api/index_patterns.js
@@ -6,7 +6,7 @@
 import { callWithRequestFactory } from '../../lib/call_with_request_factory';
 import { isEsErrorFactory } from '../../lib/is_es_error_factory';
 import { wrapEsError, wrapUnknownError } from '../../lib/error_wrappers';
-import { mapCapabilities } from '../../lib/map_capabilities';
+import { getCapabilitiesForIndexName } from '../../lib/map_capabilities';
 
 import indexBy from 'lodash/collection/indexBy';
 
@@ -19,7 +19,7 @@ export function registerFieldsForWildcardRoute(server) {
     config: {
       handler: async (request, reply) => {
         const {
-          pattern: index,
+          pattern: indexName,
           fields,
           meta_fields: metaFields,
         } = request.query;
@@ -28,14 +28,14 @@ export function registerFieldsForWildcardRoute(server) {
         const callWithRequest = callWithRequestFactory(server, request);
 
         try {
-          const capabilities = await callWithRequest('rollup.capabilities', {
+          const allCapabilities = await callWithRequest('rollup.capabilities', {
             indices: '_all'
           });
 
           const rollupFields = [];
-          const capabilitiesByIndex = mapCapabilities(capabilities, index)[index];
-          const jobs = capabilitiesByIndex.capabilities && Object.keys(capabilitiesByIndex.capabilities);
-          const fieldsFromFieldCapsByName = jobs && capabilitiesByIndex.capabilities[jobs[0]].fields;
+          const indexCapabilities = getCapabilitiesForIndexName(allCapabilities, indexName);
+          const jobs = indexCapabilities && Object.keys(indexCapabilities);
+          const fieldsFromFieldCapsByName = jobs && indexCapabilities[jobs[0]].fields;
 
           // Keep meta fields
           JSON.parse(metaFields).forEach(field => fieldsFromIndex[field] && rollupFields.push(fieldsFromIndex[field]));

--- a/x-pack/plugins/rollup/server/routes/api/indices.js
+++ b/x-pack/plugins/rollup/server/routes/api/indices.js
@@ -12,7 +12,7 @@ export function registerIndicesRoute(server) {
   const isEsError = isEsErrorFactory(server);
 
   server.route({
-    path: '/api/rollup/indices/{index*}',
+    path: '/api/rollup/indices',
     method: 'GET',
     handler: async (request, reply) => {
       const { index } = request.params;
@@ -29,8 +29,5 @@ export function registerIndicesRoute(server) {
         reply(wrapUnknownError(err));
       }
     },
-    // config: {
-    //   pre: [ licensePreRouting ]
-    // }
   });
 }

--- a/x-pack/plugins/rollup/server/routes/api/indices.js
+++ b/x-pack/plugins/rollup/server/routes/api/indices.js
@@ -6,7 +6,7 @@
 import { callWithRequestFactory } from '../../lib/call_with_request_factory';
 import { isEsErrorFactory } from '../../lib/is_es_error_factory';
 import { wrapEsError, wrapUnknownError } from '../../lib/error_wrappers';
-import { mapCapabilities } from '../../lib/map_capabilities';
+import { getIndexNameToCapabilitiesMap } from '../../lib/map_capabilities';
 
 export function registerIndicesRoute(server) {
   const isEsError = isEsErrorFactory(server);
@@ -21,7 +21,7 @@ export function registerIndicesRoute(server) {
         const capabilities = await callWithRequest('rollup.capabilities', {
           indices: '_all'
         });
-        reply(mapCapabilities(capabilities, index));
+        reply(getIndexNameToCapabilitiesMap(capabilities, index));
       } catch(err) {
         if (isEsError(err)) {
           return reply(wrapEsError(err));

--- a/x-pack/plugins/rollup/server/routes/api/indices.js
+++ b/x-pack/plugins/rollup/server/routes/api/indices.js
@@ -15,13 +15,12 @@ export function registerIndicesRoute(server) {
     path: '/api/rollup/indices',
     method: 'GET',
     handler: async (request, reply) => {
-      const { index } = request.params;
       const callWithRequest = callWithRequestFactory(server, request);
       try {
         const capabilities = await callWithRequest('rollup.capabilities', {
           indices: '_all'
         });
-        reply(getIndexNameToCapabilitiesMap(capabilities, index));
+        reply(getIndexNameToCapabilitiesMap(capabilities));
       } catch(err) {
         if (isEsError(err)) {
           return reply(wrapEsError(err));
@@ -29,5 +28,8 @@ export function registerIndicesRoute(server) {
         reply(wrapUnknownError(err));
       }
     },
+    // config: {
+    //   pre: [ licensePreRouting ]
+    // }
   });
 }


### PR DESCRIPTION
@jen-huang I also removed the optional `/{index*}` endpoint and some commented-out code. Is that OK? Feel free to push back if you want to keep this stuff, I just figured it made more sense to add it back once we find a use case.