### PR TITLE
[WIP] Supporting rollups in SearchSource

### DIFF
--- a/x-pack/plugins/rollup/index.js
+++ b/x-pack/plugins/rollup/index.js
@@ -7,7 +7,7 @@
 import { resolve } from 'path';
 import { PLUGIN } from './common/constants';
 import { registerLicenseChecker } from './server/lib/register_license_checker';
-import { registerIndicesRoute, registerFieldsForWildcardRoute } from './server/routes/api';
+import { registerIndicesRoute, registerFieldsForWildcardRoute, registerSearchRoute } from './server/routes/api';
 
 export function rollup(kibana)  {
   return new kibana.Plugin({
@@ -24,6 +24,7 @@ export function rollup(kibana)  {
       registerLicenseChecker(server);
       registerIndicesRoute(server);
       registerFieldsForWildcardRoute(server);
+      registerSearchRoute(server);
     }
   });
 }

--- a/x-pack/plugins/rollup/server/client/elasticsearch_rollup.js
+++ b/x-pack/plugins/rollup/server/client/elasticsearch_rollup.js
@@ -26,5 +26,20 @@ export const elasticsearchJsPlugin = (Client, config, components) => {
     ],
     method: 'GET'
   });
+
+  rollup.search = ca({
+    urls: [
+      {
+        fmt: '/<%=index%>/_rollup_search',
+        req: {
+          index: {
+            type: 'string'
+          }
+        }
+      }
+    ],
+    needBody: true,
+    method: 'POST'
+  });
 };
 

--- a/x-pack/plugins/rollup/server/routes/api/index.js
+++ b/x-pack/plugins/rollup/server/routes/api/index.js
@@ -6,3 +6,4 @@
 
 export { registerIndicesRoute } from './indices';
 export { registerFieldsForWildcardRoute } from './index_patterns';
+export { registerSearchRoute } from './search';

--- a/x-pack/plugins/rollup/server/routes/api/search.js
+++ b/x-pack/plugins/rollup/server/routes/api/search.js
@@ -1,0 +1,36 @@
+/*
+* Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+* or more contributor license agreements. Licensed under the Elastic License;
+* you may not use this file except in compliance with the Elastic License.
+*/
+import { callWithRequestFactory } from '../../lib/call_with_request_factory';
+import { isEsErrorFactory } from '../../lib/is_es_error_factory';
+import { wrapEsError, wrapUnknownError } from '../../lib/error_wrappers';
+
+export function registerSearchRoute(server) {
+  const isEsError = isEsErrorFactory(server);
+
+  server.route({
+    path: '/api/rollup/search',
+    method: 'POST',
+    handler: async (request, reply) => {
+      const { index, query } = request.payload;
+      const callWithRequest = callWithRequestFactory(server, request);
+
+      try {
+        const results = await callWithRequest('rollup.search', {
+          index,
+          body: query,
+        });
+
+        reply(results);
+      } catch(err) {
+        if (isEsError(err)) {
+          return reply(wrapEsError(err));
+        }
+
+        reply(wrapUnknownError(err));
+      }
+    },
+  });
+}


### PR DESCRIPTION
TODO:

- [x] Create API endpoint for executing a rollups search
- [ ] Update Visualize to tell SearchSource which type of search to execute
- [ ] Update SearchSource to execute appropriate search based on provided type
- [ ] Extract this logic from Visualize and SearchSource into Rollups and inject it dynamically